### PR TITLE
Add horizontal padding to footer on mobile

### DIFF
--- a/src/components/Footer.js
+++ b/src/components/Footer.js
@@ -9,7 +9,7 @@ const { color, breakpoint } = config;
 
 const StyledFooter = styled.div`
   margin-top: 1em;
-  padding: 2em 0;
+  padding: 2em 1em;
 
   width: 100%;
 


### PR DESCRIPTION
This fixes #31 by adding `1em` of padding to the left and right of the footer when on mobile screen widths, stopping the copyright text from pushing right up to the edge of the screen.

**Before:**
![image](https://user-images.githubusercontent.com/21127383/111606746-7ec8c900-87cf-11eb-8e88-846d130441e8.png)

**After:**
![image](https://user-images.githubusercontent.com/21127383/111606692-6e185300-87cf-11eb-9d9f-4329d4b3be11.png)
