### PR TITLE
Change default button hover to orange instead of translucent

### DIFF
--- a/src/components/Button.js
+++ b/src/components/Button.js
@@ -8,8 +8,6 @@ import config from "../theme/config";
 
 const { color, font, transition, breakpoint } = config;
 
-import { hexToRGBA } from "../theme/util";
-
 const StyledButton = styled(Link)`
   display: inline-block;
 
@@ -38,9 +36,8 @@ const StyledButton = styled(Link)`
   &:hover,
   &:focus,
   &:active {
-    background-color: ${({ primary }) =>
-      primary ? color.background : hexToRGBA(color.accent, 0.3)};
-    color: ${color.accent};
+    background-color: ${({ primary }) => (primary ? color.background : color.accent)};
+    color: ${({ primary }) => (primary ? color.accent : color.background)};
   }
 
   @media (${breakpoint.md}) {


### PR DESCRIPTION
Fixes #33 by changing the default button hover colors to an orange background, instead of see-through.

**Before:**
![image](https://user-images.githubusercontent.com/21127383/111607774-791fb300-87d0-11eb-84da-ccb8a4cc047a.png)

**After:**
![image](https://user-images.githubusercontent.com/21127383/111607931-9ce2f900-87d0-11eb-9b48-8e6048790063.png)
