### PR TITLE
Fix for links on contact page not working

### DIFF
--- a/src/components/Navbar.js
+++ b/src/components/Navbar.js
@@ -75,6 +75,7 @@ const StyledNavLink = styled(Link)`
 
     &:last-child {
       margin-right: 0;
+      margin-bottom: auto;
     }
 
     &::after {

--- a/src/pages/contact.js
+++ b/src/pages/contact.js
@@ -16,9 +16,9 @@ const ContactPage = () => (
     </p>
     <p>
       You can also contact us on{" "}
-      <TextLink href="https://www.messenger.com/t/102941108484310">Facebook</TextLink> and{" "}
-      <TextLink href="https://twitter.com/yordevs">Twitter</TextLink>, or{" "}
-      <TextLink href="mailto:yordevs@yusu.org" target="_blank">
+      <TextLink to="https://www.messenger.com/t/102941108484310">Facebook</TextLink> and{" "}
+      <TextLink to="https://twitter.com/yordevs">Twitter</TextLink>, or{" "}
+      <TextLink to="mailto:yordevs@yusu.org" target="_blank">
         email
       </TextLink>{" "}
       if you&apos;d prefer it!


### PR DESCRIPTION
(closes #39)

The components were using an `href` prop which the `TextLink` component doesn't have. Switched it to `to`, which is what should've been used.

Have also fixed a bug I spotted where the "hover underline" on the contact page was appearing too low down on wide viewports.