### PR TITLE
Fix footer not appearing on index page

### DIFF
--- a/src/components/Footer.js
+++ b/src/components/Footer.js
@@ -19,6 +19,8 @@ const StyledFooter = styled.div`
   background-color: ${color.text};
   color: ${color.background};
 
+  z-index: 1;
+
   @media (${breakpoint.md}) {
     background-color: ${color.background};
     color: ${color.text};


### PR DESCRIPTION
(closes #32)

Have adjusted the `z-index` of the footer so it appears above the vanta background on the index page.