### PR TITLE
Adjust content padding at large breakpoints

### DIFF
--- a/src/components/Layout.js
+++ b/src/components/Layout.js
@@ -32,10 +32,9 @@ const StyledContent = styled.main`
 
   padding: 1em;
 
-  @media (${breakpoint.md}) {
+  @media (${breakpoint.lg}) {
     padding: 1em 0;
   }
-
 `;
 
 const Layout = ({ title, description, children }) => (


### PR DESCRIPTION
Horizontal padding was being removed from the layout content at medium screen widths and upwards, meaning it was squishing right up to the edge of the page up until the 960px width