### PR TITLE
Switch to time-based modal reopen

### DIFF
--- a/src/components/Layout.js
+++ b/src/components/Layout.js
@@ -40,25 +40,31 @@ const StyledContent = styled.main`
   }
 `;
 
+const ONE_HOUR = 1 * 60 * 60 * 1000;
+
 // Workaround for triggering the modal through a useEffect, instead of some kind of event.
 const NULL_EVENT = { currentTarget: { contains: () => false } };
 
 const useModalState = createPersistedState("modalClosed");
 
 const Layout = ({ title, description, children }) => {
-  const [modalWasClosed, setModalWasClosed] = useModalState(false);
+  const [modalClosed, setModalClosed] = useModalState("");
 
   const { openPortal, closePortal, isOpen, Portal } = usePortal({
     closeOnOutsideClick: false,
     onClose() {
-      setModalWasClosed(true);
+      setModalClosed(new Date().getTime());
     },
   });
 
   useEffect(() => {
     let modalTimer;
 
-    if (!modalWasClosed) {
+    const closedOneHourAgo = modalClosed + ONE_HOUR <= new Date().getTime();
+
+    console.log(closedOneHourAgo);
+
+    if (closedOneHourAgo) {
       // Can be used to run code after a set period of time.
       // Works even if you load up home page and then switch to a different page, which is nice.
       modalTimer = setTimeout(() => {

--- a/src/components/Layout.js
+++ b/src/components/Layout.js
@@ -62,8 +62,6 @@ const Layout = ({ title, description, children }) => {
 
     const closedOneHourAgo = modalClosed + ONE_HOUR <= new Date().getTime();
 
-    console.log(closedOneHourAgo);
-
     if (closedOneHourAgo) {
       // Can be used to run code after a set period of time.
       // Works even if you load up home page and then switch to a different page, which is nice.


### PR DESCRIPTION
(closes #83)

Have switched to storing the time the modal was closed instead of a simple boolean, which means we can perform a check to see whether the current time is greater than the stored time by an hour, showing the modal if so.

Tested by reducing `ONE_HOUR` to a smaller value and manually checking that it doesn't show before the timer runs out, and _does_ show after.