### PR TITLE
Link get involved page logos to relevant sites 89

### DIFF
--- a/src/components/SocialIcon.js
+++ b/src/components/SocialIcon.js
@@ -14,6 +14,7 @@ const StyledIcon = styled.a`
 
   &:hover {
     color: ${color.accent};
+    cursor: pointer;
   }
 `;
 

--- a/src/pages/get-involved.js
+++ b/src/pages/get-involved.js
@@ -73,19 +73,19 @@ const InvolvedPage = () => {
         <p> We&apos;re currently using the following frameworks:</p>
         <ListHolder>
           <ItemHolder>
-            <TechIcon icon={<FaReact />} />
+            <TechIcon icon={<FaReact />} href={"https://reactjs.org/"} />
             <p>ReactJS</p>
           </ItemHolder>
           <ItemHolder>
-            <TechIcon icon={<GrGatsbyjs />} />
+            <TechIcon icon={<GrGatsbyjs />} href={"https://www.gatsbyjs.com/"} />
             <p>Gatsby</p>
           </ItemHolder>
           <ItemHolder>
-            <TechIcon icon={<FaReact />} />
+            <TechIcon icon={<FaReact />} href={"https://reactnative.dev/"} />
             <p>React Native</p>
           </ItemHolder>
           <ItemHolder>
-            <TechIcon icon={<FaGithub />} />
+            <TechIcon icon={<FaGithub />} href={"https://pages.github.com/"} />
             <p>Github Pages</p>
           </ItemHolder>
         </ListHolder>


### PR DESCRIPTION
1. Get Involved page logos are now clickable and linked to relevant sites. 
    A. ReactJS logo -> https://reactjs.org/
    B. Gatsby logo -> https://www.gatsbyjs.com/
    C. React Native logo -> https://reactnative.dev/
    D. Github Pages logo -> https://pages.github.com/

2. Mouse changes to pointer on hover of logos.