### PR TITLE
Prevent competition modal from showing

### DIFF
--- a/src/components/Layout.js
+++ b/src/components/Layout.js
@@ -60,7 +60,7 @@ const Layout = ({ title, description, children }) => {
   useEffect(() => {
     let modalTimer;
 
-    const closedOneHourAgo = modalClosed + ONE_HOUR <= new Date().getTime();
+    const closedOneHourAgo = modalClosed + ONE_HOUR <= new Date().getTime() && false;
 
     if (closedOneHourAgo) {
       // Can be used to run code after a set period of time.


### PR DESCRIPTION
Prevent competition modal showing on page load. I have left the code in there so we can reuse it for other events